### PR TITLE
グループ最下部へのスクロールアニメーションではなくジャンプに変更

### DIFF
--- a/app/assets/javascripts/scrollBar.js
+++ b/app/assets/javascripts/scrollBar.js
@@ -1,0 +1,16 @@
+$(function(){
+  if ($(".chat__body > li").length) {
+    var scrollStop;
+    $(".chat__body").on("scroll", function(){
+      $(".chat__body").removeClass("hide-scrollbar");
+      $(".chat__body").addClass("scrollbar");
+
+      clearTimeout(scrollStop);
+
+      scrollStop = setTimeout(function () {
+        $(".chat__body").removeClass("scrollbar");
+        $(".chat__body").addClass("hide-scrollbar");
+      }, 500);
+    })
+  }
+})

--- a/app/assets/javascripts/scrolling.js
+++ b/app/assets/javascripts/scrolling.js
@@ -1,8 +1,0 @@
-$(window).load(function () {
-  var chatBody = $(".chat__body");
-  if (chatBody.length) {
-    $(".chat__body").animate({
-      scrollTop: $(".chat__body")[0].scrollHeight
-    }, 0);
-  }
-})

--- a/app/assets/javascripts/toLatestMessage.js
+++ b/app/assets/javascripts/toLatestMessage.js
@@ -1,0 +1,6 @@
+$(window).load(function () {
+  if ($(".chat__body > li").length) {
+    var positionBottom = $(".chat__body > li:last-child").position().top;
+    $(".chat__body").scrollTop(positionBottom);
+  }
+})

--- a/app/assets/stylesheets/modules/_chat.scss
+++ b/app/assets/stylesheets/modules/_chat.scss
@@ -56,7 +56,6 @@
   height          : calc(100% - #{$chat__header-height} - #{$chat__footer-height});
   background-color: #FAFAFA;
   padding         : 26px $chat__padding--lateral;
-  @include scroll-bar;
 
   &__list {
     width    : 100%;
@@ -142,5 +141,15 @@
     background-color: $blue;
     color           : $font--white;
     @include hover();
+  }
+}
+
+.scrollbar {
+  @include scroll-bar;
+}
+
+.hide-scrollbar {
+  &::-webkit-scrollbar{
+    display: none;
   }
 }


### PR DESCRIPTION
# WHAT
- グループ最下部への移動をスクロールアニメーションさせるのをやめる

# WHY
- グループ選択の際、自動で最新メッセージまで移動させるため
- スクロールアニメーションで対応していたが、スクロールを見せる必要がないため